### PR TITLE
10 timesleep takes seconds as int and not as float

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@
 | ConvertRoman  |          ConvertRoman(str string) string {}          |                    Converts a number to a roman number                    |   N/A    |
 |     Date      | Date(year, month, day, hour, min, sec int) string {} |                 Returns a string representation of a date                 | UTC Time |
 |      Now      |                   Now() string {}                    |            Returns a string representation of the current time            |   N/A    |
-|     Sleep     |                  Sleep(sec int) {}                   |      Pauses the current goroutine for a specified number of seconds       |   N/A    |
+|     Sleep     |             Sleep(sec int \| float32) {}             |      Pauses the current goroutine for a specified number of seconds       |   N/A    |
 |   Strftime    |       Strftime(format, date string) string {}        | Returns a string representation of a date according to a specified format |   N/A    |
-|     Timer     |                  Timer(sec int) {}                   |                  Waits for a specified number of seconds                  |   N/A    |
 
 ## Supported Conversion Formats :
 | Pattern |                   Description                    |

--- a/time.go
+++ b/time.go
@@ -66,7 +66,7 @@ func ConvertRoman(str string) string {
 }
 
 // Sleep pauses the current goroutine for a specified number of seconds
-func Sleep(sec int) {
+func Sleep[T int | float32](sec T) {
 	time.Sleep(time.Duration(sec) * time.Second)
 }
 
@@ -101,10 +101,4 @@ func Strftime(format, date string) string {
 		format = format[i+2:]
 	}
 	return result
-}
-
-// Timer waits for a specified number of seconds
-func Timer(sec int) {
-	t := time.NewTimer(time.Duration(sec) * time.Second)
-	<-t.C
 }

--- a/time_test.go
+++ b/time_test.go
@@ -52,6 +52,7 @@ func TestConvertRoman(t *testing.T) {
 
 func TestSleep(t *testing.T) {
 	Sleep(2)
+	Sleep(float32(0.5))
 }
 
 func TestStrftime(t *testing.T) {
@@ -76,8 +77,4 @@ func TestStrftime(t *testing.T) {
 	if actual != expected {
 		t.Errorf("Expected %s, got %s", expected, actual)
 	}
-}
-
-func TestTimer(t *testing.T) {
-	Timer(2)
 }


### PR DESCRIPTION
allow func sleep to take float32 in parameter and remove func timer